### PR TITLE
TE-30191 Replace library django-cache-machine

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ For full docs, see https://cache-machine.readthedocs.org/en/latest/.
 Requirements
 ------------
 
-Cache Machine works with Django 1.11-2.2 and Python 2.7, 3.4, 3.5, 3.6, and 3.7.
+Cache Machine works with Django 1.11-3.2 and Python 2.7, 3.4, 3.5, 3.6, and 3.7.
 
 
 Installation

--- a/caching/ext.py
+++ b/caching/ext.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.utils import encoding
 from jinja2 import nodes

--- a/caching/invalidation.py
+++ b/caching/invalidation.py
@@ -10,8 +10,8 @@ from django.conf import settings
 from django.core.cache import cache as default_cache
 from django.core.cache import caches
 from django.core.cache.backends.base import InvalidCacheBackendError
-from django.utils import encoding, six, translation
-from django.utils.six.moves.urllib.parse import parse_qsl
+from django.utils import encoding,translation
+from urllib.parse import parse_qsl
 
 from caching import config
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import jinja2
 import logging
 import pickle

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,16 +1,9 @@
-from __future__ import unicode_literals
-
 import django
 from django.db import models
-from django.utils import six
+
+from unittest import mock
+
 from caching.base import CachingMixin, CachingManager, cached_method
-
-if six.PY3:
-    from unittest import mock
-else:
-    import mock
-
-
 # This global call counter will be shared among all instances of an Addon.
 call_counter = mock.Mock()
 


### PR DESCRIPTION
# What?
 - remove six package to support django 3.2

# Why?
 - upgrade to django 3.2