### PR TITLE
Feature/te 36106 upgrade django cache machine for django 4.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,18 +7,19 @@ through the ORM.
 
 For full docs, see https://cache-machine.readthedocs.org/en/latest/.
 
-.. image:: https://travis-ci.org/django-cache-machine/django-cache-machine.svg?branch=master
-  :target: https://travis-ci.org/django-cache-machine/django-cache-machine
-
-.. image:: https://coveralls.io/repos/django-cache-machine/django-cache-machine/badge.svg?branch=master
-  :target: https://coveralls.io/r/django-cache-machine/django-cache-machine?branch=master
+.. image:: https://github.com/django-cache-machine/django-cache-machine/actions/workflows/ci.yaml/badge.svg
+  :target: https://github.com/django-cache-machine/django-cache-machine/actions/workflows/ci.yaml
 
 
 Requirements
 ------------
 
-Cache Machine works with Django 1.11-3.2 and Python 2.7, 3.4, 3.5, 3.6, and 3.7.
+Cache Machine currently works with:
 
+* Django 2.2, 3.0, 3.1, 3.2, 4.0 and 4.2
+* Python 3.6, 3.7, 3.8, 3.9, and 3.10
+
+The last version to support Python 2.7 and Django 1.11 is ``django-cache-machine==1.1.0``.
 
 Installation
 ------------
@@ -35,5 +36,5 @@ Get it from `github <http://github.com/django-cache-machine/django-cache-machine
 
     git clone git://github.com/django-cache-machine/django-cache-machine.git
     cd django-cache-machine
-    pip install -r requirements/py3.txt  # or py2.txt for Python 2
+    pip install -r dev-requirements.txt
     python run_tests.py

--- a/caching/__init__.py
+++ b/caching/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import unicode_literals
 
-VERSION = ('1', '1', '0')
+VERSION = ('1', '2', '0')
 __version__ = '.'.join(VERSION)

--- a/caching/config.py
+++ b/caching/config.py
@@ -8,7 +8,8 @@ FETCH_BY_ID = getattr(settings, 'FETCH_BY_ID', False)
 FLUSH = CACHE_PREFIX + ':flush:'
 CACHE_EMPTY_QUERYSETS = getattr(settings, 'CACHE_EMPTY_QUERYSETS', False)
 TIMEOUT = getattr(settings, 'CACHE_COUNT_TIMEOUT', NO_CACHE)
-CACHE_INVALIDATE_ON_CREATE = getattr(settings, 'CACHE_INVALIDATE_ON_CREATE', None)
+CACHE_INVALIDATE_ON_CREATE = getattr(
+    settings, 'CACHE_INVALIDATE_ON_CREATE', None)
 CACHE_MACHINE_NO_INVALIDATION = getattr(
     settings, 'CACHE_MACHINE_NO_INVALIDATION', False
 )

--- a/caching/config.py
+++ b/caching/config.py
@@ -9,10 +9,14 @@ FLUSH = CACHE_PREFIX + ':flush:'
 CACHE_EMPTY_QUERYSETS = getattr(settings, 'CACHE_EMPTY_QUERYSETS', False)
 TIMEOUT = getattr(settings, 'CACHE_COUNT_TIMEOUT', NO_CACHE)
 CACHE_INVALIDATE_ON_CREATE = getattr(settings, 'CACHE_INVALIDATE_ON_CREATE', None)
-CACHE_MACHINE_NO_INVALIDATION = getattr(settings, 'CACHE_MACHINE_NO_INVALIDATION', False)
+CACHE_MACHINE_NO_INVALIDATION = getattr(
+    settings, 'CACHE_MACHINE_NO_INVALIDATION', False
+)
 CACHE_MACHINE_USE_REDIS = getattr(settings, 'CACHE_MACHINE_USE_REDIS', False)
 
 _invalidate_on_create_values = (None, WHOLE_MODEL)
 if CACHE_INVALIDATE_ON_CREATE not in _invalidate_on_create_values:
-    raise ValueError('CACHE_INVALIDATE_ON_CREATE must be one of: '
-                     '%s' % _invalidate_on_create_values)
+    raise ValueError(
+        'CACHE_INVALIDATE_ON_CREATE must be one of: '
+        '%s' % _invalidate_on_create_values
+    )

--- a/caching/ext.py
+++ b/caching/ext.py
@@ -18,7 +18,8 @@ class FragmentCacheExtension(Extension):
 
     Derived from the jinja2 documentation example.
     """
-    tags = set(['cache'])
+
+    tags = set(["cache"])
 
     def __init__(self, environment):
         super(FragmentCacheExtension, self).__init__(environment)
@@ -35,30 +36,31 @@ class FragmentCacheExtension(Extension):
         lineno = next(parser.stream).lineno
 
         # Use the filename + line number and first object for the cache key.
-        name = '%s+%s' % (self.name, lineno)
+        name = "%s+%s" % (self.name, lineno)
         args = [nodes.Const(name), parser.parse_expression()]
 
         # If there is a comma, the user provided a timeout.  If not, use
         # None as second parameter.
         timeout = nodes.Const(None)
         extra = nodes.Const([])
-        while parser.stream.skip_if('comma'):
+        while parser.stream.skip_if("comma"):
             x = parser.parse_expression()
-            if parser.stream.current.type == 'assign':
+            if parser.stream.current.type == "assign":
                 next(parser.stream)
                 extra = parser.parse_expression()
             else:
                 timeout = x
         args.extend([timeout, extra])
 
-        body = parser.parse_statements(['name:endcache'], drop_needle=True)
+        body = parser.parse_statements(["name:endcache"], drop_needle=True)
 
         self.process_cache_arguments(args)
 
         # now return a `CallBlock` node that calls our _cache_support
         # helper method on this extension.
-        return nodes.CallBlock(self.call_method('_cache_support', args),
-                               [], [], body).set_lineno(lineno)
+        return nodes.CallBlock(
+            self.call_method("_cache_support", args), [], [], body
+        ).set_lineno(lineno)
 
     def process_cache_arguments(self, args):
         """Extension point for adding anything extra to the cache_support."""
@@ -68,8 +70,8 @@ class FragmentCacheExtension(Extension):
         """Cache helper callback."""
         if settings.DEBUG:
             return caller()
-        extra = ':'.join(map(encoding.smart_str, extra))
-        key = 'fragment:%s:%s' % (name, extra)
+        extra = ":".join(map(encoding.smart_str, extra))
+        key = "fragment:%s:%s" % (name, extra)
         return caching.base.cached_with(obj, caller, key, timeout)
 
 

--- a/caching/invalidation.py
+++ b/caching/invalidation.py
@@ -74,13 +74,15 @@ def safe_redis(return_type):
 
 
 class Invalidator(object):
-    def invalidate_objects(self, objects, is_new_instance=False, model_cls=None):
+    def invalidate_objects(self, objects, is_new_instance=False,
+                           model_cls=None):
         """Invalidate all the flush lists for the given ``objects``."""
         obj_keys = [k for o in objects for k in o._cache_keys()]
         flush_keys = [k for o in objects for k in o._flush_keys()]
-        # If whole-model invalidation on create is enabled, include this model's
-        # key in the list to be invalidated. Note that the key itself won't
-        # contain anything in the cache, but its corresponding flush key will.
+        # If whole-model invalidation on create is enabled, include
+        # this model's key in the list to be invalidated.
+        # Note that the key itself won't contain anything in the cache,
+        # but its corresponding flush key will.
         if (
             config.CACHE_INVALIDATE_ON_CREATE == config.WHOLE_MODEL
             and is_new_instance
@@ -145,7 +147,8 @@ class Invalidator(object):
                 else:
                     obj_keys.add(key)
             if new_keys:
-                log.debug('search for %s found keys %s' % (search_keys, new_keys))
+                log.debug(
+                    'search for %s found keys %s' % (search_keys, new_keys))
                 flush_keys.update(new_keys)
                 search_keys = new_keys
             else:
@@ -166,7 +169,8 @@ class Invalidator(object):
         """Return a set of object keys from the lists in `keys`."""
         return set(
             e
-            for flush_list in [_f for _f in list(cache.get_many(keys).values()) if _f]
+            for flush_list in [
+                _f for _f in list(cache.get_many(keys).values()) if _f]
             for e in flush_list
         )
 
@@ -215,7 +219,8 @@ def parse_backend_uri(backend_uri):
     """
     backend_uri_sliced = backend_uri.split('://')
     if len(backend_uri_sliced) > 2:
-        raise InvalidCacheBackendError("Backend URI can't have more than one scheme://")
+        raise InvalidCacheBackendError(
+            "Backend URI can't have more than one scheme://")
     elif len(backend_uri_sliced) == 2:
         rest = backend_uri_sliced[1]
     else:
@@ -224,7 +229,7 @@ def parse_backend_uri(backend_uri):
     host = rest
     qpos = rest.find('?')
     if qpos != -1:
-        params = dict(parse_qsl(rest[qpos + 1 :]))
+        params = dict(parse_qsl(rest[qpos + 1:]))
         host = rest[:qpos]
     else:
         params = {}
@@ -258,7 +263,8 @@ def get_redis_backend():
         host = 'localhost'
         port = 6379
     return redislib.Redis(
-        host=host, port=port, db=db, password=password, socket_timeout=socket_timeout
+        host=host, port=port, db=db, password=password,
+        socket_timeout=socket_timeout
     )
 
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,12 @@
+# These are the reqs to build docs and run tests.
+sphinx
+django-redis
+jinja2
+redis
+flake8
+coverage
+psycopg2-binary
+dj-database-url
+python-memcached>=1.58
+tox
+tox-gh-actions

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,8 +15,8 @@ master_doc = 'index'
 extensions = ['sphinx.ext.autodoc']
 
 # General information about the project.
-project = u'Cache Machine'
-copyright = u'2010, The Zamboni Collective'
+project = 'Cache Machine'
+copyright = '2010, The Zamboni Collective'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -105,7 +105,7 @@ cleared.  To avoid stale foreign key relations, any cached objects will be
 flushed when the object their foreign key points to is invalidated.
 
 During cache invalidation, we explicitly set a None value instead of just
-deleting so we don't have any race condtions where:
+deleting so we don't have any race conditions where:
 
  * Thread 1 -> Cache miss, get object from DB
  * Thread 2 -> Object saved, deleted from cache

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -3,6 +3,14 @@
 Release Notes
 ==================
 
+v1.2.0 (2022-07-06)
+-------------------
+
+- Drop official support for unsupported Django versions (1.11, 2.0, 2.1)
+- Add support for Django 3.0, 3.1, 3.2, and 4.2
+- Add support for Python 3.8, 3.9, and 3.10
+- Switch to GitHub Actions
+
 v1.1.0 (2019-02-17)
 -------------------
 
@@ -38,8 +46,8 @@ v0.9.1 (2015-10-22)
 - Fix bug that prevented caching objects forever when using Django <= 1.5
   (see PR #104)
 - Fix regression (introduced in 0.8) that broke invalidation when an object
-  was cached via a slave database and later modified or deleted via the
-  master database, when using master/slave replication (see PR #105). Note
+  was cached via a replica database and later modified or deleted via the
+  primary database, when using primary/replica replication (see PR #105). Note
   this change may cause unexpected invalidation when sharding across DBs
   that share both a schema and primary key values or other attributes.
 

--- a/examples/cache_machine/custom_backend.py
+++ b/examples/cache_machine/custom_backend.py
@@ -6,7 +6,7 @@ CACHES = {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
     },
     'cache_machine': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
         'LOCATION': 'localhost:11211',
     },
 }

--- a/examples/cache_machine/settings.py
+++ b/examples/cache_machine/settings.py
@@ -1,5 +1,6 @@
 import os
 
+import dj_database_url
 import django
 
 CACHES = {
@@ -9,33 +10,19 @@ CACHES = {
     },
 }
 
-TEST_RUNNER = 'django_nose.runner.NoseTestSuiteRunner'
-
 DATABASES = {
-    'default': {
-        'NAME': os.environ.get('TRAVIS') and 'travis_ci_test' or 'cache_machine_devel',
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-    },
-    'slave': {
-        'NAME': 'cache_machine_devel',
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'TEST_MIRROR': 'default',  # support older Django syntax for now
-    },
-    'master2': {
-        'NAME': os.environ.get('TRAVIS') and 'travis_ci_test2' or 'cache_machine_devel2',
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-    },
-    'slave2': {
-        'NAME': 'cache_machine_devel2',
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'TEST_MIRROR': 'master2',  # support older Django syntax for now
-    },
+    "default": dj_database_url.config(default="postgres:///cache_machine_devel"),
+    "primary2": dj_database_url.parse(
+        os.getenv("DATABASE_URL_2", "postgres:///cache_machine_devel2")
+    ),
 }
+for primary, replica in (("default", "replica"), ("primary2", "replica2")):
+    DATABASES[replica] = DATABASES[primary].copy()
+    DATABASES[replica]["TEST"] = {"MIRROR": primary}
 
-INSTALLED_APPS = (
-    'django_nose',
-    'tests.testapp',
-)
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
+INSTALLED_APPS = ('tests.testapp',)
 
 SECRET_KEY = 'ok'
 

--- a/examples/cache_machine/settings.py
+++ b/examples/cache_machine/settings.py
@@ -11,7 +11,8 @@ CACHES = {
 }
 
 DATABASES = {
-    "default": dj_database_url.config(default="postgres:///cache_machine_devel"),
+    "default": dj_database_url.config(
+        default="postgres:///cache_machine_devel"),
     "primary2": dj_database_url.parse(
         os.getenv("DATABASE_URL_2", "postgres:///cache_machine_devel2")
     ),

--- a/run_tests.py
+++ b/run_tests.py
@@ -27,17 +27,25 @@ SETTINGS = (
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Run the tests for django-cache-machine. '
-                                     'If no options are specified, tests will be run with '
-                                     'all settings files and without coverage.py.')
-    parser.add_argument('--with-coverage', action='store_true',
-                        help='Run tests with coverage.py and display coverage report')
-    parser.add_argument('--settings', choices=SETTINGS,
-                        help='Run tests only for the specified settings file')
+    parser = argparse.ArgumentParser(
+        description='Run the tests for django-cache-machine. '
+        'If no options are specified, tests will be run with '
+        'all settings files and without coverage.py.'
+    )
+    parser.add_argument(
+        '--with-coverage',
+        action='store_true',
+        help='Run tests with coverage.py and display coverage report',
+    )
+    parser.add_argument(
+        '--settings',
+        choices=SETTINGS,
+        help='Run tests only for the specified settings file',
+    )
     args = parser.parse_args()
     settings = args.settings and [args.settings] or SETTINGS
     results = []
-    django_admin = check_output(['which', 'django-admin.py']).strip()
+    django_admin = check_output(['which', 'django-admin']).strip()
     for i, settings_module in enumerate(settings):
         print('Running tests for: %s' % settings_module)
         os.environ['DJANGO_SETTINGS_MODULE'] = 'cache_machine.%s' % settings_module

--- a/run_tests.py
+++ b/run_tests.py
@@ -48,7 +48,8 @@ def main():
     django_admin = check_output(['which', 'django-admin']).strip()
     for i, settings_module in enumerate(settings):
         print('Running tests for: %s' % settings_module)
-        os.environ['DJANGO_SETTINGS_MODULE'] = 'cache_machine.%s' % settings_module
+        os.environ['DJANGO_SETTINGS_MODULE'] = (
+                'cache_machine.%s' % settings_module)
         # append to the existing coverage data for all but the first run
         if args.with_coverage and i > 0:
             test_cmd = ['coverage', 'run', '--append']
@@ -59,7 +60,8 @@ def main():
         test_cmd += [django_admin, 'test', '--keepdb']
         results.append(call(test_cmd))
         if args.with_coverage:
-            results.append(call(['coverage', 'report', '-m', '--fail-under', '70']))
+            results.append(call(
+                ['coverage', 'report', '-m', '--fail-under', '70']))
     sys.exit(any(results) and 1 or 0)
 
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,9 +1,10 @@
+from unittest import mock
+
 import django
 from django.db import models
 
-from unittest import mock
+from caching.base import CachingManager, CachingMixin, cached_method
 
-from caching.base import CachingMixin, CachingManager, cached_method
 # This global call counter will be shared among all instances of an Addon.
 call_counter = mock.Mock()
 
@@ -14,15 +15,19 @@ class User(CachingMixin, models.Model):
     objects = CachingManager()
 
     if django.VERSION[0] >= 2:
+
         class Meta:
-            # Tell Django to use this manager when resolving foreign keys. (Django >= 2.0)
+            # Tell Django to use this manager when resolving foreign keys.
+            # (Django >= 2.0)
             base_manager_name = 'objects'
 
 
 class Addon(CachingMixin, models.Model):
     val = models.IntegerField()
     author1 = models.ForeignKey(User, on_delete=models.CASCADE)
-    author2 = models.ForeignKey(User, related_name='author2_set', on_delete=models.CASCADE)
+    author2 = models.ForeignKey(
+        User, related_name='author2_set', on_delete=models.CASCADE
+    )
 
     objects = CachingManager()
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,29 +4,29 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist =
-    dj{111}-py{27,34,35,36,37}
-    dj{200}-py{34,35,36,37}
-    dj{210}-py{35,36,37}
-    dj{220}-py{35,36,37}
-    py{27,37}-flake8
-    docs
+envlist = py3{6,7,8,9}-{2.2,3.0,3.1,3.2},py310-3.2,py3{8,9,10}-{4.0}
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
 
 [testenv]
-basepython =
-    py27: python2.7
-    py34: python3.4
-    py35: python3.5
-    py36: python3.6
-    py37: python3.7
 commands = {envpython} run_tests.py --with-coverage
+passenv =
+  DATABASE_URL
+  DATABASE_URL_2
 deps =
-    py27: -rrequirements/py2.txt
-    py{34,35,36,37}: -rrequirements/py3.txt
-    dj111: Django>=1.11,<2.0
-    dj200: Django>=2.0,<2.1
-    dj210: Django>=2.1,<2.2
-    dj220: Django==2.2b1
+    -rdev-requirements.txt
+    2.2: Django>=2.2,<3.0
+    3.0: Django>=3.0,<3.1
+    3.1: Django>=3.1,<3.2
+    3.2: Django>=3.2,<4.0
+    4.0: Django>=4.0,<4.1
+    4.2: Django>=4.2,<5.0
 
 [testenv:docs]
 basepython = python3.7
@@ -38,10 +38,6 @@ setenv =
     DJANGO_SETTINGS_MODULE = cache_machine.settings
 changedir = docs
 commands = /usr/bin/make html
-
-[testenv:py27-flake8]
-deps = flake8
-commands = flake8
 
 [testenv:py37-flake8]
 deps = flake8


### PR DESCRIPTION
what?
---
Updated code for Django 4.2 compatibility
Changed encoding.smart_text to encoding.smart_str 
Changed cache machine backend MemcachedCache to PyMemcacheCache
Changed 'django-admin.py' to 'django-admin'
Removed Unicode string representation of 'u' prefix before a string literal
created dev-requirements.txt


why
---
To support Django 4.2
smart_text is removed in Django 4.2
MemcachedCache is removed in Django 4.2
django-admin.py is removed in Django 4.2
'u' prefix is no longer needed in python 3.x