### PR TITLE
TE-36106 : Make django 4.2 compatible changes to django-cache-machine repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,12 @@ For full docs, see https://cache-machine.readthedocs.org/en/latest/.
 Requirements
 ------------
 
-Cache Machine works with Django 1.11-3.2 and Python 2.7, 3.4, 3.5, 3.6, and 3.7.
+Cache Machine currently works with:
 
+* Django 2.2, 3.0, 3.1, 3.2, 4.0 and 4.2
+* Python 3.6, 3.7, 3.8, 3.9, and 3.10
+
+The last version to support Python 2.7 and Django 1.11 is ``django-cache-machine==1.1.0``.
 
 Installation
 ------------
@@ -35,5 +39,5 @@ Get it from `github <http://github.com/django-cache-machine/django-cache-machine
 
     git clone git://github.com/django-cache-machine/django-cache-machine.git
     cd django-cache-machine
-    pip install -r requirements/py3.txt  # or py2.txt for Python 2
+    pip install -r dev-requirements.txt
     python run_tests.py

--- a/caching/__init__.py
+++ b/caching/__init__.py
@@ -1,4 +1,2 @@
-from __future__ import unicode_literals
-
-VERSION = ('1', '1', '0')
+VERSION = ('1', '3', '0')
 __version__ = '.'.join(VERSION)

--- a/caching/base.py
+++ b/caching/base.py
@@ -273,7 +273,7 @@ class CachingMixin(object):
             key_parts = ('o', cls._meta, pk, db)
         else:
             key_parts = ('o', cls._meta, pk)
-        return ':'.join(map(encoding.smart_text, key_parts))
+        return ':'.join(map(encoding.smart_str, key_parts))
 
     def _cache_keys(self, incl_db=True):
         """Return the cache key for self plus all related foreign keys."""
@@ -347,10 +347,10 @@ def cached_with(obj, f, f_key, timeout=DEFAULT_TIMEOUT):
         obj_key = (obj.query_key() if hasattr(obj, 'query_key')
                    else obj.cache_key)
     except (AttributeError, EmptyResultSet):
-        log.warning('%r cannot be cached.' % encoding.smart_text(obj))
+        log.warning('%r cannot be cached.' % encoding.smart_str(obj))
         return f()
 
-    key = '%s:%s' % tuple(map(encoding.smart_text, (f_key, obj_key)))
+    key = '%s:%s' % tuple(map(encoding.smart_str, (f_key, obj_key)))
     # Put the key generated in cached() into this object's flush list.
     invalidator.add_to_flush_list(
         {obj.flush_key(): [_function_cache_key(key)]})
@@ -401,7 +401,7 @@ class MethodWrapper(object):
         kwarg_keys = [(key, k(val)) for key, val in list(kwargs.items())]
         key_parts = ('m', self.obj.cache_key, self.func.__name__,
                      arg_keys, kwarg_keys)
-        key = ':'.join(map(encoding.smart_text, key_parts))
+        key = ':'.join(map(encoding.smart_str, key_parts))
         if key not in self.cache:
             f = functools.partial(self.func, self.obj, *args, **kwargs)
             self.cache[key] = cached_with(self.obj, f, key)

--- a/caching/invalidation.py
+++ b/caching/invalidation.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import collections
 import functools
 import hashlib

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,10 +1,12 @@
 # These are the reqs to build docs and run tests.
 sphinx
-django-nose
 django-redis
 jinja2
 redis
 flake8
 coverage
-psycopg2
+psycopg2-binary
+dj-database-url
 python-memcached>=1.58
+tox
+tox-gh-actions

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,8 +15,8 @@ master_doc = 'index'
 extensions = ['sphinx.ext.autodoc']
 
 # General information about the project.
-project = u'Cache Machine'
-copyright = u'2010, The Zamboni Collective'
+project = 'Cache Machine'
+copyright = '2010, The Zamboni Collective'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -3,6 +3,14 @@
 Release Notes
 ==================
 
+v1.3.0 (2024-02-23)
+-------------------
+
+- Drop official support for unsupported Django versions (1.11, 2.0, 2.1)
+- Add support for Django 3.0, 3.1, 3.2, 4.0 and 4.2
+- Add support for Python 3.8, 3.9, and 3.10
+- Switch to GitHub Actions
+
 v1.1.0 (2019-02-17)
 -------------------
 
@@ -38,8 +46,8 @@ v0.9.1 (2015-10-22)
 - Fix bug that prevented caching objects forever when using Django <= 1.5
   (see PR #104)
 - Fix regression (introduced in 0.8) that broke invalidation when an object
-  was cached via a slave database and later modified or deleted via the
-  master database, when using master/slave replication (see PR #105). Note
+  was cached via a replica database and later modified or deleted via the
+  primary database, when using primary/replica replication (see PR #105). Note
   this change may cause unexpected invalidation when sharding across DBs
   that share both a schema and primary key values or other attributes.
 

--- a/examples/cache_machine/custom_backend.py
+++ b/examples/cache_machine/custom_backend.py
@@ -6,7 +6,7 @@ CACHES = {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
     },
     'cache_machine': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
         'LOCATION': 'localhost:11211',
     },
 }

--- a/examples/cache_machine/settings.py
+++ b/examples/cache_machine/settings.py
@@ -9,44 +9,30 @@ CACHES = {
     },
 }
 
-TEST_RUNNER = 'django_nose.runner.NoseTestSuiteRunner'
-
 DATABASES = {
-    'default': {
-        'NAME': os.environ.get('TRAVIS') and 'travis_ci_test' or 'cache_machine_devel',
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-    },
-    'slave': {
-        'NAME': 'cache_machine_devel',
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'TEST_MIRROR': 'default',  # support older Django syntax for now
-    },
-    'master2': {
-        'NAME': os.environ.get('TRAVIS') and 'travis_ci_test2' or 'cache_machine_devel2',
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-    },
-    'slave2': {
-        'NAME': 'cache_machine_devel2',
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'TEST_MIRROR': 'master2',  # support older Django syntax for now
-    },
+    "default": dj_database_url.config(default="postgres:///cache_machine_devel"),
+    "primary2": dj_database_url.parse(
+        os.getenv("DATABASE_URL_2", "postgres:///cache_machine_devel2")
+    ),
 }
+for primary, replica in (("default", "replica"), ("primary2", "replica2")):
+    DATABASES[replica] = DATABASES[primary].copy()
+    DATABASES[replica]["TEST"] = {"MIRROR": primary}
 
-INSTALLED_APPS = (
-    'django_nose',
-    'tests.testapp',
-)
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
-SECRET_KEY = 'ok'
+INSTALLED_APPS = ("tests.testapp",)
+
+SECRET_KEY = "ok"
 
 MIDDLEWARE_CLASSES = (
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.auth.middleware.SessionAuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
 )
 
 if django.VERSION[0] >= 2:

--- a/requirements/py2.txt
+++ b/requirements/py2.txt
@@ -1,2 +1,0 @@
--r base.txt
-mock==1.0.1

--- a/requirements/py3.txt
+++ b/requirements/py3.txt
@@ -1,1 +1,0 @@
--r base.txt

--- a/run_tests.py
+++ b/run_tests.py
@@ -37,7 +37,7 @@ def main():
     args = parser.parse_args()
     settings = args.settings and [args.settings] or SETTINGS
     results = []
-    django_admin = check_output(['which', 'django-admin.py']).strip()
+    django_admin = check_output(['which', 'django-admin']).strip()
     for i, settings_module in enumerate(settings):
         print('Running tests for: %s' % settings_module)
         os.environ['DJANGO_SETTINGS_MODULE'] = 'cache_machine.%s' % settings_module

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -554,57 +554,64 @@ class CachingTestCase(TestCase):
 # use TransactionTestCase so that ['TEST']['MIRROR'] setting works
 # see https://code.djangoproject.com/ticket/23718
 class MultiDbTestCase(TransactionTestCase):
-    multi_db = True
-    fixtures = ['tests/testapp/fixtures/testapp/test_cache.json']
-    extra_apps = ['tests.testapp']
+    databases = {"default", "primary2", "replica", "replica2"}
+    fixtures = ["tests/testapp/fixtures/testapp/test_cache.json"]
+    extra_apps = ["tests.testapp"]
 
     def test_multidb_cache(self):
-        """ Test where master and slave DB result in two different cache keys """
+        """Test where primary and replica DB result in two different cache keys"""
         self.assertIs(Addon.objects.get(id=1).from_cache, False)
         self.assertIs(Addon.objects.get(id=1).from_cache, True)
 
-        from_slave = Addon.objects.using('slave').get(id=1)
-        self.assertIs(from_slave.from_cache, False)
-        self.assertEqual(from_slave._state.db, 'slave')
+        from_replica = Addon.objects.using("replica").get(id=1)
+        self.assertIs(from_replica.from_cache, False)
+        self.assertEqual(from_replica._state.db, "replica")
 
     def test_multidb_fetch_by_id(self):
-        """ Test where master and slave DB result in two different cache keys with FETCH_BY_ID"""
+        """
+        Test where primary and replica DB result in two different cache keys
+        with FETCH_BY_ID
+        """
         with self.settings(FETCH_BY_ID=True):
             self.assertIs(Addon.objects.get(id=1).from_cache, False)
             self.assertIs(Addon.objects.get(id=1).from_cache, True)
 
-            from_slave = Addon.objects.using('slave').get(id=1)
-            self.assertIs(from_slave.from_cache, False)
-            self.assertEqual(from_slave._state.db, 'slave')
+            from_replica = Addon.objects.using("replica").get(id=1)
+            self.assertIs(from_replica.from_cache, False)
+            self.assertEqual(from_replica._state.db, "replica")
 
-    def test_multidb_master_slave_invalidation(self):
-        """ Test saving an object on one DB invalidates it for all DBs """
-        log.debug('priming the DB & cache')
-        master_obj = User.objects.using('default').create(name='new-test-user')
-        slave_obj = User.objects.using('slave').get(name='new-test-user')
-        self.assertIs(slave_obj.from_cache, False)
-        log.debug('deleting the original object')
-        User.objects.using('default').filter(pk=slave_obj.pk).delete()
-        log.debug('re-creating record with a new primary key')
-        master_obj = User.objects.using('default').create(name='new-test-user')
-        log.debug('attempting to force re-fetch from DB (should not use cache)')
-        slave_obj = User.objects.using('slave').get(name='new-test-user')
-        self.assertIs(slave_obj.from_cache, False)
-        self.assertEqual(slave_obj.pk, master_obj.pk)
+    def test_multidb_primary_replica_invalidation(self):
+        """Test saving an object on one DB invalidates it for all DBs"""
+        log.debug("priming the DB & cache")
+        primary_obj = User.objects.using("default").create(name="new-test-user")
+        replica_obj = User.objects.using("replica").get(name="new-test-user")
+        self.assertIs(replica_obj.from_cache, False)
+        log.debug("deleting the original object")
+        User.objects.using("default").filter(pk=replica_obj.pk).delete()
+        log.debug("re-creating record with a new primary key")
+        primary_obj = User.objects.using("default").create(name="new-test-user")
+        log.debug("attempting to force re-fetch from DB (should not use cache)")
+        replica_obj = User.objects.using("replica").get(name="new-test-user")
+        self.assertIs(replica_obj.from_cache, False)
+        self.assertEqual(replica_obj.pk, primary_obj.pk)
 
     def test_multidb_no_db_crossover(self):
-        """ Test no crossover of objects with identical PKs """
-        master_obj = User.objects.using('default').create(name='new-test-user')
-        master_obj2 = User.objects.using('master2').create(pk=master_obj.pk, name='other-test-user')
+        """Test no crossover of objects with identical PKs"""
+        primary_obj = User.objects.using("default").create(name="new-test-user")
+        primary_obj2 = User.objects.using("primary2").create(
+            pk=primary_obj.pk,
+            name="other-test-user",
+        )
         # prime the cache for the default DB
-        master_obj = User.objects.using('default').get(name='new-test-user')
-        self.assertIs(master_obj.from_cache, False)
-        master_obj = User.objects.using('default').get(name='new-test-user')
-        self.assertIs(master_obj.from_cache, True)
-        # prime the cache for the 2nd master DB
-        master_obj2 = User.objects.using('master2').get(name='other-test-user')
-        self.assertIs(master_obj2.from_cache, False)
-        master_obj2 = User.objects.using('master2').get(name='other-test-user')
-        self.assertIs(master_obj2.from_cache, True)
+        primary_obj = User.objects.using("default").get(name="new-test-user")
+        self.assertIs(primary_obj.from_cache, False)
+        primary_obj = User.objects.using("default").get(name="new-test-user")
+        self.assertIs(primary_obj.from_cache, True)
+        # prime the cache for the 2nd primary DB
+        primary_obj2 = User.objects.using("primary2").get(name="other-test-user")
+        self.assertIs(primary_obj2.from_cache, False)
+        primary_obj2 = User.objects.using("primary2").get(name="other-test-user")
+        self.assertIs(primary_obj2.from_cache, True)
         # ensure no crossover between databases
-        self.assertNotEqual(master_obj.name, master_obj2.name)
+        self.assertNotEqual(primary_obj.name, primary_obj2.name)
+

--- a/tox.ini
+++ b/tox.ini
@@ -4,44 +4,36 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist =
-    dj{111}-py{27,34,35,36,37}
-    dj{200}-py{34,35,36,37}
-    dj{210}-py{35,36,37}
-    dj{220}-py{35,36,37}
-    py{27,37}-flake8
-    docs
+envlist = py3{6,7,8,9}-{2.2,3.0,3.1,3.2},py310-3.2,py3{8,9,10}-{4.0}
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
 
 [testenv]
-basepython =
-    py27: python2.7
-    py34: python3.4
-    py35: python3.5
-    py36: python3.6
-    py37: python3.7
 commands = {envpython} run_tests.py --with-coverage
+passenv =
+  DATABASE_URL
+  DATABASE_URL_2
 deps =
-    py27: -rrequirements/py2.txt
-    py{34,35,36,37}: -rrequirements/py3.txt
-    dj111: Django>=1.11,<2.0
-    dj200: Django>=2.0,<2.1
-    dj210: Django>=2.1,<2.2
-    dj220: Django==2.2b1
+    -rdev-requirements.txt
+    2.2: Django>=2.2,<3.0
+    3.0: Django>=3.0,<3.1
+    3.1: Django>=3.1,<3.2
+    3.2: Django>=3.2,<4.0
+    4.0: Django>=4.0,<4.1
+    4.1: Django>=4.0,<4.2
+    4.2: Django>=4.2,<5.0
 
 [testenv:docs]
 basepython = python3.7
-deps =
-    Sphinx
-    Django
-setenv =
-    PYTHONPATH = {toxinidir}/examples/
-    DJANGO_SETTINGS_MODULE = cache_machine.settings
+	@@ -39,10 +39,6 @@ setenv =
 changedir = docs
 commands = /usr/bin/make html
-
-[testenv:py27-flake8]
-deps = flake8
-commands = flake8
 
 [testenv:py37-flake8]
 deps = flake8


### PR DESCRIPTION
what?
---
Updated code for Django 4.2 compatibility
Changed encoding.smart_text to encoding.smart_str 
Changed cache machine backend MemcachedCache to PyMemcacheCache
Changed 'django-admin.py' to 'django-admin'
Removed Unicode string representation of 'u' prefix before a string literal
created dev-requirements.txt


why
---
To support Django 4.2
smart_text is removed in Django 4.2
MemcachedCache is removed in Django 4.2
django-admin.py is removed in Django 4.2
'u' prefix is no longer needed in python 3.x