### PR TITLE
TE-38808: Upgrade django-cache-machine for compatibility with Django 5.2.10 and Python 3.10.16

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,9 +19,10 @@ Requirements
 
 Cache Machine currently works with:
 
-* Django 2.2, 3.0, 3.1, 3.2, 4.0 and 4.2
-* Python 3.6, 3.7, 3.8, 3.9, and 3.10
+* Django 4.2, 5.0, 5.1, and 5.2
+* Python 3.10, 3.11, and 3.12
 
+The last version to support Python 3.9 and Django 4.0/4.1 is ``django-cache-machine==1.2.0``.
 The last version to support Python 2.7 and Django 1.11 is ``django-cache-machine==1.1.0``.
 
 Installation

--- a/caching/base.py
+++ b/caching/base.py
@@ -19,9 +19,6 @@ log = logging.getLogger('caching')
 
 class CachingManager(models.Manager):
 
-    # This option removed in Django 2.0
-    # Tell Django to use this manager when resolving foreign keys. (Django < 2.0)
-    use_for_related_fields = True
 
     def get_queryset(self):
         return CachingQuerySet(self.model, using=self._db)
@@ -293,10 +290,7 @@ class CachingMixin(object):
         return map(flush_key, self._cache_keys(incl_db=False))
 
     def _get_fk_related_model(self, fk):
-        if django.VERSION[0] >= 2:
-            return fk.remote_field.model
-        else:
-            return fk.rel.to
+        return fk.remote_field.model
 
 
 class CachingRawQuerySet(models.query.RawQuerySet):

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,12 +1,13 @@
 # These are the reqs to build docs and run tests.
-sphinx
-django-redis
-jinja2
-redis
-flake8
-coverage
-psycopg2-binary
-dj-database-url
-python-memcached>=1.58
-tox
-tox-gh-actions
+Django>=5.2.10,<5.3
+sphinx>=4.0
+django-redis>=5.0
+jinja2>=3.0
+redis>=4.0
+flake8>=6.0
+coverage>=6.0
+psycopg2-binary>=2.9
+dj-database-url>=2.0
+pymemcache>=4.0
+tox>=4.0
+tox-gh-actions>=3.0

--- a/examples/cache_machine/settings.py
+++ b/examples/cache_machine/settings.py
@@ -1,10 +1,11 @@
 import os
 
+import dj_database_url
 import django
 
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
         'LOCATION': 'localhost:11211',
     },
 }
@@ -25,15 +26,12 @@ INSTALLED_APPS = ("tests.testapp",)
 
 SECRET_KEY = "ok"
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.contrib.auth.middleware.SessionAuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 )
 
-if django.VERSION[0] >= 2:
-    MIDDLEWARE = MIDDLEWARE_CLASSES

--- a/setup.py
+++ b/setup.py
@@ -15,22 +15,24 @@ setup(
     packages=['caching'],
     include_package_data=True,
     zip_safe=False,
+    python_requires='>=3.10',
+    install_requires=[
+        'Django>=5.2,<5.3',
+    ],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',
         # I don't know what exactly this means, but why not?
         'Environment :: Web Environment :: Mozilla',
         'Framework :: Django',
+        'Framework :: Django :: 5.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ]
 )

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -13,10 +13,9 @@ class User(CachingMixin, models.Model):
 
     objects = CachingManager()
 
-    if django.VERSION[0] >= 2:
-        class Meta:
-            # Tell Django to use this manager when resolving foreign keys. (Django >= 2.0)
-            base_manager_name = 'objects'
+    class Meta:
+        # Tell Django to use this manager when resolving foreign keys. (Django >= 2.0)
+        base_manager_name = 'objects'
 
 
 class Addon(CachingMixin, models.Model):
@@ -29,6 +28,8 @@ class Addon(CachingMixin, models.Model):
     class Meta:
         # without this, Postgres & SQLite return objects in different orders:
         ordering = ('pk',)
+        # Tell Django to use this manager when resolving foreign keys. (Django >= 2.0)
+        base_manager_name = 'objects'
 
     @cached_method
     def calls(self, arg=1):

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,13 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py3{6,7,8,9}-{2.2,3.0,3.1,3.2},py310-3.2,py3{8,9,10}-{4.0}
+envlist = py3{10,11,12}-{4.2,5.0,5.1,5.2}
 
 [gh-actions]
 python =
-    3.6: py36
-    3.7: py37
-    3.8: py38
-    3.9: py39
     3.10: py310
+    3.11: py311
+    3.12: py312
 
 [testenv]
 commands = {envpython} run_tests.py --with-coverage
@@ -21,13 +19,10 @@ passenv =
   DATABASE_URL_2
 deps =
     -rdev-requirements.txt
-    2.2: Django>=2.2,<3.0
-    3.0: Django>=3.0,<3.1
-    3.1: Django>=3.1,<3.2
-    3.2: Django>=3.2,<4.0
-    4.0: Django>=4.0,<4.1
-    4.1: Django>=4.0,<4.2
     4.2: Django>=4.2,<5.0
+    5.0: Django>=5.0,<5.1
+    5.1: Django>=5.1,<5.2
+    5.2: Django>=5.2,<5.3
 
 [testenv:docs]
 basepython = python3.7


### PR DESCRIPTION
What?
---
Upgrade django-cache-machine for compatibility with Django 5.2.10 and Python 3.10.16.

Why?
---
To make codebase compatible with Django 5.2.10 & Python 3.10.16 Upgarde.

Ticket:
--- 
https://eptura.atlassian.net/browse/TE-38808